### PR TITLE
Adds support for string slices

### DIFF
--- a/config.go
+++ b/config.go
@@ -136,12 +136,8 @@ func LoadConfig(filename string, config interface{}) error {
 				return fmt.Errorf("Mismatched types between slice and value")
 			}
 
-			// Create slice of value given in config-file.
-			s := reflect.MakeSlice(reflect.SliceOf(v.Type()), 0, 0)
-			s = reflect.Append(s, v)
-
-			// Add this slice (with one element) to the config-slice.
-			field.Set(reflect.AppendSlice(field, s))
+			// Add value the config-slice.
+			field.Set(reflect.Append(field, v))
 		default:
 			return fmt.Errorf("Unsupported type: %s", field.Kind())
 		}


### PR DESCRIPTION
By defining two variables on the same Key and given that the key is
defined as a []string slice, the first string is not overwritten but
instead we append the second value.

E.g. we define our struct:

```
type Config struct {
    Foo []string
}
```

And now we can say:

```
Foo = "Loreum"
Foo = "Ipsum"
```

And the resulting config.Foo will be the slice `[]string{"Loreum",
"Ipsum"}`. Currently only support for string slices, as we need to check
the slice-type and then convert Value-string to correct type as we
already do - and I could not (yet) figure a smart way of doing this
without repeating the code.
